### PR TITLE
FastCRC - A more efficient CRC calculation

### DIFF
--- a/pyModeS/decoder/fastcrc.py
+++ b/pyModeS/decoder/fastcrc.py
@@ -1,0 +1,45 @@
+GENERATOR = [int("11111111", 2), int("11111010", 2), int("00000100", 2), int("10000000", 2)]
+
+
+class BytesWrapper:
+
+    def __init__(self, hex: str):
+        if len(hex) % 2 == 1:
+            hex += '0'
+
+        self._bytes = [b for b in bytes.fromhex(hex)]
+
+    def byte_count(self) -> int:
+        return len(self._bytes) - 3
+
+    def get_bit(self, byte_index, bit_index):
+        mask = 0x80 >> bit_index
+        bits = self._bytes[byte_index] & mask
+        return 0 if bits == 0 else 1
+
+    def apply_matrix(self, byte_index, bit_index):
+        self._bytes[byte_index] = self._bytes[byte_index] ^ (GENERATOR[0] >> bit_index)
+        self._bytes[byte_index + 1] = self._bytes[byte_index + 1] ^ \
+                                      (0xFF & ((GENERATOR[0] << 8 - bit_index) | (GENERATOR[1] >> bit_index)))
+        self._bytes[byte_index + 2] = self._bytes[byte_index + 2] ^ \
+                                      (0xFF & ((GENERATOR[1] << 8 - bit_index) | (GENERATOR[2] >> bit_index)))
+        self._bytes[byte_index + 3] = self._bytes[byte_index + 3] ^ \
+                                      (0xFF & ((GENERATOR[2] << 8 - bit_index) | (GENERATOR[3] >> bit_index)))
+
+    def get_suffix(self) -> int:
+        return (self._bytes[-3] << 16) | (self._bytes[-2] << 8) | self._bytes[-1]
+
+
+def crc(msg: str) -> int:
+    msgbin = BytesWrapper(msg)
+
+    for byte_index in range(msgbin.byte_count()):
+        for bit_index in range(8):
+            b = msgbin.get_bit(byte_index, bit_index)
+
+            if b == 1:
+                msgbin.apply_matrix(byte_index, bit_index)
+
+    result = msgbin.get_suffix()
+
+    return result

--- a/pyModeS/decoder/fastcrc.py
+++ b/pyModeS/decoder/fastcrc.py
@@ -9,7 +9,7 @@ class BytesWrapper:
 
         self._bytes = [b for b in bytes.fromhex(hex)]
 
-    def byte_count(self) -> int:
+    def byte_count(self):
         return len(self._bytes) - 3
 
     def get_bit(self, byte_index, bit_index):
@@ -30,7 +30,7 @@ class BytesWrapper:
         return (self._bytes[-3] << 16) | (self._bytes[-2] << 8) | self._bytes[-1]
 
 
-def crc(msg: str) -> int:
+def crc(msg):
     msgbin = BytesWrapper(msg)
 
     for byte_index in range(msgbin.byte_count()):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,13 +5,24 @@ def test_hex2bin():
     assert common.hex2bin('6E406B') == "011011100100000001101011"
 
 def test_crc_decode():
-    for i in range(5000):
-        checksum = common.crc("8D406B902015A678D4D220AA4BDA")
-        assert checksum == "000000000000000000000000"
+    assert common.crc("8D406B902015A678D4D220AA4BDA") == 0
+    assert common.crc('8d8960ed58bf053cf11bc5932b7d') == 0
+    assert common.crc('8d45cab390c39509496ca9a32912') == 0
+    assert common.crc('8d49d3d4e1089d00000000744c3b') == 0
+    assert common.crc('8d74802958c904e6ef4ba0184d5c') == 0
+    assert common.crc('8d4400cd9b0000b4f87000e71a10') == 0
+    assert common.crc('8d4065de58a1054a7ef0218e226a') == 0
+
+    assert common.crc('c80b2dca34aa21dd821a04cb64d4') == 10719924
+    assert common.crc('a800089d8094e33a6004e4b8a522') == 4805588
+    assert common.crc('a8000614a50b6d32bed000bbe0ed') == 5659991
+    assert common.crc('a0000410bc900010a40000f5f477') == 11727682
+    assert common.crc('8d4ca251204994b1c36e60a5343d') == 16
+    assert common.crc('b0001718c65632b0a82040715b65') == 353333
 
 def test_crc_encode():
     parity = common.crc("8D406B902015A678D4D220AA4BDA", encode=True)
-    assert common.hex2bin("AA4BDA") == parity
+    assert int("AA4BDA", 16) == parity
 
 def test_icao():
     assert common.icao("8D406B902015A678D4D220AA4BDA") == "406B90"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,8 +5,9 @@ def test_hex2bin():
     assert common.hex2bin('6E406B') == "011011100100000001101011"
 
 def test_crc_decode():
-    checksum = common.crc("8D406B902015A678D4D220AA4BDA")
-    assert checksum == "000000000000000000000000"
+    for i in range(5000):
+        checksum = common.crc("8D406B902015A678D4D220AA4BDA")
+        assert checksum == "000000000000000000000000"
 
 def test_crc_encode():
     parity = common.crc("8D406B902015A678D4D220AA4BDA", encode=True)


### PR DESCRIPTION
The current CRC function is slow and creates a bottleneck in my current project that has to validate large volumes of messages.

I propose to backport my changes for the future version pyModeS 2.0:

- An updated CRC calculation that computes bitmasks directly
- CRC function now returns integer
- Additional unit test cases