### PR TITLE
streamer.screen: fix undefined variable icao on emty flight list

### DIFF
--- a/pyModeS/streamer/screen.py
+++ b/pyModeS/streamer/screen.py
@@ -101,6 +101,7 @@ class Screen(Thread):
         icaos = np.sort(icaos)
 
         for row in range(3, self.scr_h - 3):
+            icao = None
             idx = row + self.offset
 
             if idx > len(icaos) - 1:


### PR DESCRIPTION
The icao variable is tested for None on line 136 but is not defined if
no flight is known