### PR TITLE
streamer.screen: fix missing flights in view

### DIFF
--- a/pyModeS/streamer/screen.py
+++ b/pyModeS/streamer/screen.py
@@ -102,7 +102,7 @@ class Screen(Thread):
 
         for row in range(3, self.scr_h - 3):
             icao = None
-            idx = row + self.offset
+            idx = row + self.offset - 3
 
             if idx > len(icaos) - 1:
                 line = ' '*(self.scr_w-2)


### PR DESCRIPTION
the row is countin from 3 to the window hight, but the idx ist used
as index into the icaos list beginning at 0. the offset is 0 for the
first page. This results in the first 3 flights not shown.