### PR TITLE
Additional Information Extracted from TC-19/BDS0,9 Messages

### DIFF
--- a/pyModeS/decoder/adsb.py
+++ b/pyModeS/decoder/adsb.py
@@ -159,9 +159,10 @@ def velocity(msg, rtn_sources=False):
             ground track or heading (degree),
             rate of climb/descent (ft/min), speed type
             ('GS' for ground speed, 'AS' for airspeed),
-            direction source ('true_north' for ground track, 'mag_north' for
-            magnetic heading), rate of climb/descent source ('Baro' for
-            barometer, 'GNSS' for GNSS constellation).
+            direction source ('true_north' for ground track / true north
+            as refrence, 'mag_north' for magnetic north as reference),
+            rate of climb/descent source ('Baro' for barometer, 'GNSS'
+            for GNSS constellation).
             
             In the case of surface messages, None will be put in place
             for vertical rate and its respective sources.

--- a/pyModeS/decoder/adsb.py
+++ b/pyModeS/decoder/adsb.py
@@ -151,9 +151,16 @@ def velocity(msg):
         msg (string): 28 bytes hexadecimal message string
 
     Returns:
-        (int, float, int, string): speed (kt), ground track or heading (degree),
-            rate of climb/descend (ft/min), and speed type
-            ('GS' for ground speed, 'AS' for airspeed)
+        (int, float, int, string, string, string): speed (kt),
+            ground track or heading (degree),
+            rate of climb/descent (ft/min), speed type
+            ('GS' for ground speed, 'AS' for airspeed),
+            direction source ('gnd_trk' for ground track, 'mag_hdg' for
+            magnetic heading), rate of climb/descent source ('Baro' for
+            barometer, 'GNSS' for GNSS constellation).
+            
+            In the case of surface messages, None will be put in place
+            for direction, vertical rate, and their respective sources.
     """
 
     if 5 <= typecode(msg) <= 8:

--- a/pyModeS/decoder/adsb.py
+++ b/pyModeS/decoder/adsb.py
@@ -159,7 +159,7 @@ def velocity(msg, rtn_sources=False):
             ground track or heading (degree),
             rate of climb/descent (ft/min), speed type
             ('GS' for ground speed, 'AS' for airspeed),
-            direction source ('gnd_trk' for ground track, 'mag_hdg' for
+            direction source ('true_north' for ground track, 'mag_north' for
             magnetic heading), rate of climb/descent source ('Baro' for
             barometer, 'GNSS' for GNSS constellation).
             

--- a/pyModeS/decoder/adsb.py
+++ b/pyModeS/decoder/adsb.py
@@ -143,12 +143,16 @@ def altitude(msg):
         return None
 
 
-def velocity(msg):
+def velocity(msg, rtn_sources=False):
     """Calculate the speed, heading, and vertical rate
     (handles both airborne or surface message)
 
     Args:
         msg (string): 28 bytes hexadecimal message string
+        rtn_source (boolean): If the function will return
+            the sources for direction of travel and vertical
+            rate. This will change the return value from a four
+            element array to a six element array.
 
     Returns:
         (int, float, int, string, string, string): speed (kt),
@@ -160,14 +164,14 @@ def velocity(msg):
             barometer, 'GNSS' for GNSS constellation).
             
             In the case of surface messages, None will be put in place
-            for direction, vertical rate, and their respective sources.
+            for vertical rate and its respective sources.
     """
 
     if 5 <= typecode(msg) <= 8:
-        return surface_velocity(msg)
+        return surface_velocity(msg, rtn_sources)
 
     elif typecode(msg) == 19:
-        return airborne_velocity(msg)
+        return airborne_velocity(msg, rtn_sources)
 
     else:
         raise RuntimeError("incorrect or inconsistant message types, expecting 4<TC<9 or TC=19")

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -154,7 +154,8 @@ def surface_velocity(msg, rtn_sources=False):
         (int, float, int, string, string, None): speed (kt),
             ground track (degree), None for rate of climb/descend (ft/min),
             and speed type ('GS' for ground speed), direction source
-            ('true_north' for ground track), None rate of climb/descent source.
+            ('true_north' for ground track / true north as reference),
+            None rate of climb/descent source.
     """
 
     if common.typecode(msg) < 5 or common.typecode(msg) > 8:

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -154,7 +154,7 @@ def surface_velocity(msg, rtn_sources=False):
         (int, float, int, string, string, None): speed (kt),
             ground track (degree), None for rate of climb/descend (ft/min),
             and speed type ('GS' for ground speed), direction source
-            ('gnd_trk' for ground track), None rate of climb/descent source.
+            ('true_north' for ground track), None rate of climb/descent source.
     """
 
     if common.typecode(msg) < 5 or common.typecode(msg) > 8:
@@ -188,6 +188,6 @@ def surface_velocity(msg, rtn_sources=False):
         spd = round(spd, 2)
 
     if rtn_sources:
-        return spd, trk, 0, 'GS', 'gnd_trk', None
+        return spd, trk, 0, 'GS', 'true_north', None
     else:
         return spd, trk, 0, 'GS'

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -147,9 +147,10 @@ def surface_velocity(msg):
         msg (string): 28 bytes hexadecimal message string
 
     Returns:
-        (int, float, int, string): speed (kt), ground track (degree),
-            rate of climb/descend (ft/min), and speed type
-            ('GS' for ground speed, 'AS' for airspeed)
+        (int, float, None, string, None, None): speed (kt),
+            ground track (degree), None for rate of climb/descend (ft/min),
+            and speed type ('GS' for ground speed), direction source
+            ('gnd_trk' for ground track), None rate of climb/descent source.
     """
 
     if common.typecode(msg) < 5 or common.typecode(msg) > 8:
@@ -182,4 +183,4 @@ def surface_velocity(msg):
         spd = kts[i-1] + (mov-movs[i-1]) * step
         spd = round(spd, 2)
 
-    return spd, trk, 0, 'GS'
+    return spd, trk, None, 'GS', None, None

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -141,13 +141,17 @@ def surface_position_with_ref(msg, lat_ref, lon_ref):
     return round(lat, 5), round(lon, 5)
 
 
-def surface_velocity(msg):
+def surface_velocity(msg, rtn_sources=False):
     """Decode surface velocity from from a surface position message
     Args:
         msg (string): 28 bytes hexadecimal message string
+        rtn_source (boolean): If the function will return
+            the sources for direction of travel and vertical
+            rate. This will change the return value from a four
+            element array to a six element array.
 
     Returns:
-        (int, float, None, string, string, None): speed (kt),
+        (int, float, int, string, string, None): speed (kt),
             ground track (degree), None for rate of climb/descend (ft/min),
             and speed type ('GS' for ground speed), direction source
             ('gnd_trk' for ground track), None rate of climb/descent source.
@@ -183,4 +187,7 @@ def surface_velocity(msg):
         spd = kts[i-1] + (mov-movs[i-1]) * step
         spd = round(spd, 2)
 
-    return spd, trk, None, 'GS', 'gnd_trk', None
+    if rtn_sources:
+        return spd, trk, 0, 'GS', 'gnd_trk', None
+    else:
+        return spd, trk, 0, 'GS'

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -147,7 +147,7 @@ def surface_velocity(msg):
         msg (string): 28 bytes hexadecimal message string
 
     Returns:
-        (int, float, None, string, None, None): speed (kt),
+        (int, float, None, string, string, None): speed (kt),
             ground track (degree), None for rate of climb/descend (ft/min),
             and speed type ('GS' for ground speed), direction source
             ('gnd_trk' for ground track), None rate of climb/descent source.
@@ -183,4 +183,4 @@ def surface_velocity(msg):
         spd = kts[i-1] + (mov-movs[i-1]) * step
         spd = round(spd, 2)
 
-    return spd, trk, None, 'GS', None, None
+    return spd, trk, None, 'GS', 'gnd_trk', None

--- a/pyModeS/decoder/bds/bds09.py
+++ b/pyModeS/decoder/bds/bds09.py
@@ -25,11 +25,15 @@ from pyModeS.decoder import common
 import math
 
 
-def airborne_velocity(msg):
+def airborne_velocity(msg, rtn_sources=False):
     """Calculate the speed, track (or heading), and vertical rate
 
     Args:
         msg (string): 28 bytes hexadecimal message string
+        rtn_source (boolean): If the function will return
+            the sources for direction of travel and vertical
+            rate. This will change the return value from a four
+            element array to a six element array.
 
     Returns:
         (int, float, int, string, string, string): speed (kt),
@@ -96,7 +100,11 @@ def airborne_velocity(msg):
     vr = common.bin2int(mb[37:46])
     rocd = None if vr==0 else int(vr_sign*(vr-1)*64)
 
-    return spd, trk_or_hdg, rocd, tag, dir_type, vr_source
+    if rtn_sources:
+        return spd, trk_or_hdg, rocd, tag, dir_type, vr_source
+    else:
+        return spd, trk_or_hdg, rocd, tag
+    
 
 def altitude_diff(msg):
     """Decode the differece between GNSS and barometric altitude

--- a/pyModeS/decoder/bds/bds09.py
+++ b/pyModeS/decoder/bds/bds09.py
@@ -32,9 +32,13 @@ def airborne_velocity(msg):
         msg (string): 28 bytes hexadecimal message string
 
     Returns:
-        (int, float, int, string): speed (kt), ground track or heading (degree),
-            rate of climb/descend (ft/min), and speed type
-            ('GS' for ground speed, 'AS' for airspeed)
+        (int, float, int, string, string, string): speed (kt),
+            ground track or heading (degree),
+            rate of climb/descent (ft/min), speed type
+            ('GS' for ground speed, 'AS' for airspeed),
+            direction source ('gnd_trk' for ground track, 'mag_hdg' for
+            magnetic heading), rate of climb/descent source ('Baro' for
+            barometer, 'GNSS' for GNSS constellation)
     """
 
     if common.typecode(msg) != 19:
@@ -66,6 +70,7 @@ def airborne_velocity(msg):
 
         tag = 'GS'
         trk_or_hdg = round(trk, 2)
+        dir_type = 'gnd_trk'
 
     else:
         if mb[13] == '0':
@@ -83,12 +88,15 @@ def airborne_velocity(msg):
             tag = 'IAS'
         else:
             tag = 'TAS'
+        
+        dir_type = 'mag_hdg'
 
+    vr_source = 'GNSS' if mb[35]=='0' else 'Baro'
     vr_sign = -1 if mb[36]=='1' else 1
     vr = common.bin2int(mb[37:46])
     rocd = None if vr==0 else int(vr_sign*(vr-1)*64)
 
-    return spd, trk_or_hdg, rocd, tag
+    return spd, trk_or_hdg, rocd, tag, dir_type, vr_source
 
 def altitude_diff(msg):
     """Decode the differece between GNSS and barometric altitude

--- a/pyModeS/decoder/bds/bds09.py
+++ b/pyModeS/decoder/bds/bds09.py
@@ -40,7 +40,7 @@ def airborne_velocity(msg, rtn_sources=False):
             ground track or heading (degree),
             rate of climb/descent (ft/min), speed type
             ('GS' for ground speed, 'AS' for airspeed),
-            direction source ('gnd_trk' for ground track, 'mag_hdg' for
+            direction source ('true_north' for ground track, 'mag_north' for
             magnetic heading), rate of climb/descent source ('Baro' for
             barometer, 'GNSS' for GNSS constellation)
     """
@@ -74,7 +74,7 @@ def airborne_velocity(msg, rtn_sources=False):
 
         tag = 'GS'
         trk_or_hdg = round(trk, 2)
-        dir_type = 'gnd_trk'
+        dir_type = 'true_north'
 
     else:
         if mb[13] == '0':
@@ -93,7 +93,7 @@ def airborne_velocity(msg, rtn_sources=False):
         else:
             tag = 'TAS'
         
-        dir_type = 'mag_hdg'
+        dir_type = 'mag_north'
 
     vr_source = 'GNSS' if mb[35]=='0' else 'Baro'
     vr_sign = -1 if mb[36]=='1' else 1

--- a/pyModeS/decoder/bds/bds09.py
+++ b/pyModeS/decoder/bds/bds09.py
@@ -40,9 +40,10 @@ def airborne_velocity(msg, rtn_sources=False):
             ground track or heading (degree),
             rate of climb/descent (ft/min), speed type
             ('GS' for ground speed, 'AS' for airspeed),
-            direction source ('true_north' for ground track, 'mag_north' for
-            magnetic heading), rate of climb/descent source ('Baro' for
-            barometer, 'GNSS' for GNSS constellation)
+            direction source ('true_north' for ground track / true north
+            as refrence, 'mag_north' for magnetic north as reference),
+            rate of climb/descent source ('Baro' for barometer, 'GNSS'
+            for GNSS constellation).
     """
 
     if common.typecode(msg) != 19:


### PR DESCRIPTION
I added two more list elements to `airborne_velocity()` return. The elements are the sources for direction (ground track or magnetic heading) and vertical rate (barometric or GNSS). The positions of the source elements correspond to the pattern of the first three elements.

I also made a modification to `surface_velocity()` to return a six element list. It keeps the same format as for `airborne_velocity()`, but substitutes `'gnd_trk'` for direction source and `None` for vertical speed and its source.