### PR TITLE
Add debugging option

### DIFF
--- a/pyModeS/extra/tcpclient.py
+++ b/pyModeS/extra/tcpclient.py
@@ -269,7 +269,16 @@ class BaseClient(Thread):
 
                 time.sleep(0.001)
             except Exception as e:
-                print("Unexpected Error:", e)
+
+                # Provides the user an option to supply the environment 
+                # variable PYMODES_DEBUG to halt the execution
+                # for debugging purposes
+                debug_intent = os.environ.get('PYMODES_DEBUG', None)
+                if debug_intent.lower() == 'true':
+                    sys.exc_info()
+                    sys.exit()
+                else:
+                    print("Unexpected Error:", e)
 
                 try:
                     sock = self.connect()

--- a/pyModeS/extra/tcpclient.py
+++ b/pyModeS/extra/tcpclient.py
@@ -275,7 +275,7 @@ class BaseClient(Thread):
                 # for debugging purposes
                 debug_intent = os.environ.get('PYMODES_DEBUG', None)
                 if debug_intent.lower() == 'true':
-                    sys.exc_info()
+                    print(sys.exc_info())
                     sys.exit()
                 else:
                     print("Unexpected Error:", e)

--- a/pyModeS/extra/tcpclient.py
+++ b/pyModeS/extra/tcpclient.py
@@ -7,6 +7,7 @@ import sys
 import socket
 import time
 from threading import Thread
+import traceback
 
 if (sys.version_info > (3, 0)):
     PY_VERSION = 3
@@ -275,7 +276,7 @@ class BaseClient(Thread):
                 # for debugging purposes
                 debug_intent = os.environ.get('PYMODES_DEBUG', None)
                 if debug_intent.lower() == 'true':
-                    print(sys.exc_info())
+                    traceback.print_exc()
                     sys.exit()
                 else:
                     print("Unexpected Error:", e)


### PR DESCRIPTION
The TCP BaseClient class is modified to recognize the environment variable `PYMODES_DEBUG`. When the variable is set to `'true'`, the stream will halt execution and provide a traceback rather than restarting. This is for debugging purposes and does not alter the main functionality of the program.

This modification helped me identify erroneous messages from a dump1090 beast feed. Without the error message and break, all I had been provided was `invalid literal for int() with base 2: ''`.
More information on that problem is contained in issue #42.