### PR TITLE
Corrected ADS-B emitter category parsing.

### DIFF
--- a/pyModeS/decoder/bds/bds08.py
+++ b/pyModeS/decoder/bds/bds08.py
@@ -37,7 +37,8 @@ def category(msg):
         raise RuntimeError("%s: Not a identification message" % msg)
 
     msgbin = common.hex2bin(msg)
-    return common.bin2int(msgbin[5:8])
+    mebin = msgbin[32:87]
+    return common.bin2int(mebin[5:8])
 
 
 def callsign(msg):


### PR DESCRIPTION
Fixed a bug in bds08.py -> category(msg). The function returns now the right ADS-B emitter category number.
