### PR TITLE
Fix surface positions for negative longitude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,13 @@ target/
 
 # PyCharm
 .idea/
+
+# Environments
+.env
+.venv
+.virtualenvs
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,5 @@ target/
 # Environments
 .env
 .venv
-.virtualenvs
 env/
 venv/
-ENV/
-env.bak/
-venv.bak/

--- a/pyModeS/decoder/bds/bds06.py
+++ b/pyModeS/decoder/bds/bds06.py
@@ -89,6 +89,9 @@ def surface_position(msg0, msg1, t0, t1, lat_ref, lon_ref):
     # four possible longitude solutions
     lons = [lon, lon + 90.0, lon + 180.0, lon + 270.0]
 
+    # make sure lons are between -180 and 180
+    lons = [(l + 180) % 360 - 180 for l in lons]
+
     # the closest solution to receiver is the correct one
     dls = [abs(lon_ref - l) for l in lons]
     imin = min(range(4), key=dls.__getitem__)

--- a/tests/test_bds_inference.py
+++ b/tests/test_bds_inference.py
@@ -18,3 +18,18 @@ def test_bds_is50or60():
     assert bds.is50or60("A0001838201584F23468207CDFA5", 0, 0, 0) == None
     assert bds.is50or60("A0000000FFDA9517000464000000", 182, 237, 1250) == 'BDS50'
     assert bds.is50or60("A0000000919A5927E23444000000", 413, 54, 18700) == 'BDS60'
+
+
+def test_surface_position():
+    msg0 = "8FE48C033A9FA184B934E744C6FD"
+    msg1 = "8FE48C033A9FA68F7C3D39B1C2F0"
+
+    t0 = 1565608663102
+    t1 = 1565608666214
+
+    lat_ref = -23.4265448
+    lon_ref = -46.4816258
+
+    lat, lon = bds.bds06.surface_position(msg0, msg1, t0, t1, lat_ref, lon_ref)
+
+    assert abs(lon_ref - lon) < 0.05


### PR DESCRIPTION
Hi Junzi Sun,

First of all, great work on the pyModeS project, it is of great help in my coding activities! 

When decoding surface position messages with the receiver reference location in the western hemisphere, I found that these messages were wrongly decoded. This is because the four possible longitude solutions are all positive, between 0 and 360 degrees, whereas the reference location has a negative longitude (i.e. between -180 and 0). Your algorithm always picks the longitude closest to the reference location. For example, when the four possible longitudes are [45, 135, 225, 315] and my reference location is -45, the decoded longitude will be +45.

A one line fix places all four possible longitudes between -180 and +180, before choosing the one that is closest to the reference location. So in the example the possible longitudes would be [45, 135, -135, -45] and the decoded longitude would be -45. I've added a small test with two messages on the western hemisphere to verify the new correct functionality.

Regards,
Richard 