### PR TITLE
moved pms.adsb.surface_velocity under typecode 5-8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,7 @@ Core functions for ADS-B decoding
   pms.adsb.position(msg_even, msg_odd, t_even, t_odd, lat_ref=None, lon_ref=None)
   pms.adsb.airborne_position(msg_even, msg_odd, t_even, t_odd)
   pms.adsb.surface_position(msg_even, msg_odd, t_even, t_odd, lat_ref, lon_ref)
+  pms.adsb.surface_velocity(msg)
 
   pms.adsb.position_with_ref(msg, lat_ref, lon_ref)
   pms.adsb.airborne_position_with_ref(msg, lat_ref, lon_ref)
@@ -174,7 +175,6 @@ Core functions for ADS-B decoding
   # Typecode: 19
   pms.adsb.velocity(msg)          # Handles both surface & airborne messages
   pms.adsb.speed_heading(msg)     # Handles both surface & airborne messages
-  pms.adsb.surface_velocity(msg)
   pms.adsb.airborne_velocity(msg)
 
 


### PR DESCRIPTION
I tried to `pms.adsb.surface_velocity()` as per README with a typecode 19 msg and got an error:

```python
>>> import pyModeS as pms
>>> msg = '8d484966990076b9e0762d5ff92c'
>>> pms.adsb.typecode(msg)
19
>>> pms.adsb.surface_velocity(msg)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\spi\AppData\Roaming\Python\Python27\site-packages\pyModeS\decoder\bds\bds06.py", line 162, in surface_velocity
    raise RuntimeError("%s: Not a surface message, expecting 5<TC<8" % msg)
RuntimeError: 8d484966990076b9e0762d5ff92c: Not a surface message, expecting 5<TC<8
```

so I propose this fix.
I used pyModeS      2.2