### PR TITLE
Make `callsign` function accept messages as bytes.

### DIFF
--- a/pyModeS/decoder/bds/bds08.py
+++ b/pyModeS/decoder/bds/bds08.py
@@ -6,6 +6,9 @@
 
 from __future__ import absolute_import, print_function, division
 
+from binascii import hexlify
+from functools import singledispatch
+
 from pyModeS import common
 
 
@@ -27,16 +30,24 @@ def category(msg):
     return common.bin2int(mebin[5:8])
 
 
+@singledispatch
 def callsign(msg):
     """Aircraft callsign
 
     Args:
-        msg (string): 28 bytes hexadecimal message string
+        msg (string or bytes): 28 bytes hexadecimal message string or 14 bytes
 
     Returns:
         string: callsign
     """
+    raise ValueError('Unknown message type: {}'.format(type(msg)))
 
+@callsign.register
+def _callsign_str(msg: bytes):
+    return _callsign_str(hexlify(msg))
+
+@callsign.register
+def _callsign_str(msg: str):
     if common.typecode(msg) < 1 or common.typecode(msg) > 4:
         raise RuntimeError("%s: Not a identification message" % msg)
 

--- a/tests/test_adsb.py
+++ b/tests/test_adsb.py
@@ -1,3 +1,4 @@
+from binascii import unhexlify
 from pyModeS import adsb
 
 # === TEST ADS-B package ===
@@ -11,8 +12,13 @@ def test_adsb_category():
     assert adsb.category("8D406B902015A678D4D220AA4BDA") == 0
 
 
-def test_adsb_callsign():
+def test_adsb_callsign_str():
     assert adsb.callsign("8D406B902015A678D4D220AA4BDA") == "EZY85MH_"
+
+
+def test_adsb_callsign_bytes():
+    msg = unhexlify("8D406B902015A678D4D220AA4BDA")
+    assert adsb.callsign(msg) == "EZY85MH_"
 
 
 def test_adsb_position():


### PR DESCRIPTION
The pyModeS accepts messages in hex string format only. The change
allows the pyModeS API to accept messages in binary format also.

Once all functions are changed to accept both message formats, the
internals of pyModeS can be flipped to use binary data. This, hopefully,
will make the library bit faster for applications processing binary
messages only.

See also discussion in https://github.com/junzis/pyModeS/issues/61.