### PR TITLE
Continue reading from socket if no data received

### DIFF
--- a/pyModeS/extra/tcpclient.py
+++ b/pyModeS/extra/tcpclient.py
@@ -282,6 +282,8 @@ class TcpClient(object):
 
                 # raise RuntimeError("test exception")
 
+            except zmq.error.Again:
+                continue
             except Exception as e:
                 tb = traceback.format_exc()
                 exception_queue.put(tb)


### PR DESCRIPTION
Without this change, `modeslive` crashes if no data is available on the socket, which can happen during normal operation of a receiver if no aircraft are in range.

Tested on Python 3.7