### PR TITLE
Fix invalid socket disconnect call in TcpClient

### DIFF
--- a/pyModeS/extra/tcpclient.py
+++ b/pyModeS/extra/tcpclient.py
@@ -32,7 +32,7 @@ class TcpClient(object):
         self.socket.connect("tcp://%s:%s" % (self.host, self.port))
 
     def stop(self):
-        self.socket.disconnect()
+        self.socket.close()
 
     def read_raw_buffer(self):
         """ Read raw ADS-B data type.
@@ -292,4 +292,7 @@ if __name__ == "__main__":
     port = int(sys.argv[2])
     datatype = sys.argv[3]
     client = TcpClient(host=host, port=port, datatype=datatype)
-    client.run()
+    try:
+        client.run()
+    finally:
+        client.stop()


### PR DESCRIPTION
Hi, a small fix. The `disconnect` call in `TcpClient` can't be called without parameters. A better option is to completely close the socket instead IMHO. The testing main function now also stops the Client explicitly, so the `stop` function gets "tested" each time the main is executed.