### PR TITLE
Fix UnboundLocalError in airborne_velocity when velocity is zero

### DIFF
--- a/pyModeS/decoder/bds/bds09.py
+++ b/pyModeS/decoder/bds/bds09.py
@@ -65,8 +65,9 @@ def airborne_velocity(msg, source=False):
             trk = math.degrees(trk)  # convert to degrees
             trk = trk if trk >= 0 else trk + 360  # no negative val
 
+            trk_or_hdg = round(trk, 2)
+
         spd_type = "GS"
-        trk_or_hdg = round(trk, 2)
         dir_type = "TRUE_NORTH"
 
     else:


### PR DESCRIPTION
Hi, this fixes `trk` not being defined in case the branch on line 43 is executed.