### PR TITLE
Update bds61.py

### DIFF
--- a/pyModeS/decoder/bds/bds61.py
+++ b/pyModeS/decoder/bds/bds61.py
@@ -77,7 +77,7 @@ def emergency_squawk(msg: str) -> str:
     msgbin = common.hex2bin(msg)
 
     # construct the 13 bits Mode A ID code
-    idcode = msgbin[43:49] + "0" + msgbin[49:55]
+    idcode = msgbin[43:56]
 
     squawk = common.squawk(idcode)
     return squawk


### PR DESCRIPTION
Fix the Mode A decoder. The ZERO is already part of  the binary data inside the message and does not need to be added.

See ED-102A, 2.2.3.2.7.8.1.2 b. Starting with ―ME‖ bit 12, the code sequence shall be C1, A1, C2, A2, C4, A4, ZERO, B1, D1, B2, D2, B4, D4.