### PR TITLE
Bds62 baro rounding fix

### DIFF
--- a/pyModeS/decoder/__init__.py
+++ b/pyModeS/decoder/__init__.py
@@ -127,7 +127,7 @@ def tell(msg: str) -> None:
                 lnav = adsb.lnav_mode(msg)
                 _print("Selected altitude", alt, "feet")
                 _print("Altitude source", alt_source)
-                _print("Barometric pressure setting", baro, "millibars")
+                _print("Barometric pressure setting", baro, "" if baro == None else "millibars")
                 _print("Selected Heading", hdg, "°")
                 if not (common.bin2int((common.hex2bin(msg)[32:])[46]) == 0):
                     _print("Autopilot", types_29[autopilot] if autopilot else None)

--- a/pyModeS/decoder/__init__.py
+++ b/pyModeS/decoder/__init__.py
@@ -2,7 +2,7 @@ def tell(msg: str) -> None:
     from pyModeS import common, adsb, commb, bds
 
     def _print(label, value, unit=None):
-        print("%20s: " % label, end="")
+        print("%28s: " % label, end="")
         print("%s " % value, end="")
         if unit:
             print(unit)

--- a/pyModeS/decoder/bds/bds62.py
+++ b/pyModeS/decoder/bds/bds62.py
@@ -274,8 +274,7 @@ def baro_pressure_setting(msg):
         )
 
     baro = common.bin2int(mb[20:29])
-    baro = None if baro == 0 else 800 + (baro - 1) * 0.8
-    baro = round(baro, 1)
+    baro = None if baro == 0 else round(800 + (baro - 1) * 0.8, 1)
 
     return baro
 


### PR DESCRIPTION
#### Reference Issue

- [Issue "Type Error" #128](https://github.com/junzis/pyModeS/issues/128#issue-1306851214) 

#### Problem(s)

1. The `round(baro, 1)` call on line 277 in bds62.py was being called when `baro` was 'None'. 
2. (minor) Padding in `_print()` wasn't sufficient for the `baro` readout 
3. (minor) Output would display units when value was 'None.'

#### Fix Actions Taken

1. Wrapped the `else` clause with the round call so it was only called if `baro` held a numeric value.
2. Updated the output padding from 20 chars to 28 chars 
3. Added a conditional to remove the "millibars" if `baro` is 'None.'