### PR TITLE
Properly return None if altitude could not be decoded

### DIFF
--- a/pyModeS/c_common.pyx
+++ b/pyModeS/c_common.pyx
@@ -311,7 +311,7 @@ cpdef int altitude(str binstr):
 
     if bin2int(binstr) == 0:
         # altitude unknown or invalid
-        alt = -9999
+        alt = -999999
 
     elif Mbit == 48:  # unit in ft, "0" -> 48
         if Qbit == 49:  # 25ft interval, "1" -> 49

--- a/pyModeS/decoder/bds/bds05.py
+++ b/pyModeS/decoder/bds/bds05.py
@@ -152,6 +152,11 @@ def altitude(msg: str) -> None | int:
 
     if tc < 19:
         altcode = altbin[0:6] + "0" + altbin[6:]
-        return common.altitude(altcode)
+        alt = common.altitude(altcode)
+        if alt != -999999:
+            return alt
+        else:
+            # return None if altitude is invalid
+            return None
     else:
         return common.bin2int(altbin) * 3.28084  # type: ignore


### PR DESCRIPTION
c_common.py: return -999999 (extremely low, physically impossible) altitude in case altitude is unknown or invalid, bds04.py: convert -999999 altitude to None to better signal an invalid/unknown decoded altitude to the user