### PR TITLE
Fixed error when receiving NICv1 in example decoder due to mismatch in output

### DIFF
--- a/src/pyModeS/streamer/decode.py
+++ b/src/pyModeS/streamer/decode.py
@@ -165,7 +165,7 @@ class Decode:
                 ac["NUCp"], ac["HPL"], ac["RCu"], ac["RCv"] = pms.adsb.nuc_p(msg)
 
                 if (ac["ver"] == 1) and ("nic_s" in ac.keys()):
-                    ac["Rc"], ac["VPL"] = pms.adsb.nic_v1(msg, ac["nic_s"])
+                    ac["NIC"], ac["Rc"], ac["VPL"] = pms.adsb.nic_v1(msg, ac["nic_s"])
                 elif (
                     (ac["ver"] == 2)
                     and ("nic_a" in ac.keys())


### PR DESCRIPTION
Currently the current definition of the `pms.adsb.nic_v1` is as follows:

- `src/pyModeS/decoder/adsb.py`

```python
def nic_v1(msg: str, NICs: int) -> tuple[int, None | float, None | float]:
    """Calculate NIC, navigation integrity category, for ADS-B version 1

    Args:
        msg (str): 28 hexdigits string
        NICs (int or string): NIC supplement

    Returns:
        int: NIC, Navigation Integrity Category
        int or string: Horizontal Radius of Containment
        int or string: Vertical Protection Limit
    """
    tc = typecode(msg)
    if tc is None or tc < 5 or tc > 22:
        raise RuntimeError(
            "%s: Not a surface position message (5<TC<8), \
            airborne position message (8<TC<19), \
            or airborne position with GNSS height (20<TC<22)"
            % msg
        )

    NIC = uncertainty.TC_NICv1_lookup[tc]

    if isinstance(NIC, dict):
        NIC = NIC[NICs]

    d_index = uncertainty.NICv1.get(NIC, None)
    Rc, VPL = uncertainty.NA, uncertainty.NA

    if d_index is not None:
        index = d_index.get(NICs, None)
        if index is not None:
            Rc = index["Rc"]
            VPL = index["VPL"]

    return NIC, Rc, VPL
```

which returns NIC, Rc, and VPL. However, the example decoder is set for the case of NICv1 as:

- `src/pyModeS/streamer/decode.py`

```bash
ac["Rc"], ac["VPL"] = pms.adsb.nic_v1(msg, ac["nic_s"])
```

to receive only `Rc` and `VPL`. Due to this mismatch in output, the example decoder crashed on the case of `NICv1`. Since it is the example decoder, this seems not to be a critical issue. But, just to make it right, I write this PR.

Thank you in advance for your review, and please check this PR whenever available. Thank you.