### PR TITLE
Fix for a corner-case numerical problem and corresponding unit test.

### DIFF
--- a/src/pyModeS/decoder/bds/bds05.py
+++ b/src/pyModeS/decoder/bds/bds05.py
@@ -110,9 +110,8 @@ def airborne_position_with_ref(
     i = int(mb[21])
     d_lat = 360 / 59 if i else 360 / 60
 
-    j = common.floor(lat_ref / d_lat) + common.floor(
-        0.5 + ((lat_ref % d_lat) / d_lat) - cprlat
-    )
+    # From 1090 MOPS, Vol.1  DO-260C, A.1.7.5
+    j = common.floor(0.5 + lat_ref / d_lat - cprlat)
 
     lat = d_lat * (j + cprlat)
 
@@ -123,9 +122,7 @@ def airborne_position_with_ref(
     else:
         d_lon = 360
 
-    m = common.floor(lon_ref / d_lon) + common.floor(
-        0.5 + ((lon_ref % d_lon) / d_lon) - cprlon
-    )
+    m = common.floor(0.5 + lon_ref / d_lon - cprlon)
 
     lon = d_lon * (m + cprlon)
 

--- a/src/pyModeS/decoder/bds/bds06.py
+++ b/src/pyModeS/decoder/bds/bds06.py
@@ -119,9 +119,8 @@ def surface_position_with_ref(
     i = int(mb[21])
     d_lat = 90 / 59 if i else 90 / 60
 
-    j = common.floor(lat_ref / d_lat) + common.floor(
-        0.5 + ((lat_ref % d_lat) / d_lat) - cprlat
-    )
+    # From 1090 MOPS, Vol.1  DO-260C, A.1.7.6
+    j = common.floor(0.5 + lat_ref / d_lat - cprlat)
 
     lat = d_lat * (j + cprlat)
 
@@ -132,9 +131,7 @@ def surface_position_with_ref(
     else:
         d_lon = 90
 
-    m = common.floor(lon_ref / d_lon) + common.floor(
-        0.5 + ((lon_ref % d_lon) / d_lon) - cprlon
-    )
+    m = common.floor(0.5 + lon_ref / d_lon - cprlon)
 
     lon = d_lon * (m + cprlon)
 

--- a/tests/test_adsb.py
+++ b/tests/test_adsb.py
@@ -54,6 +54,15 @@ def test_adsb_airborne_position_with_ref():
     assert pos == (approx(49.81755, 0.001), approx(6.08442, 0.001))
 
 
+def test_adsb_airborne_position_with_ref_numerical_challenge():
+    lat_ref = 30.508474576271183 # Close to (360.0/59.0)*5
+    lon_ref = 7.2*5.0+3e-15
+    pos = adsb.airborne_position_with_ref(
+        "8D06A15358BF17FF7D4A84", lat_ref, lon_ref
+    )
+    assert pos == (approx(30.50540, 0.001), approx(33.44787, 0.001))
+
+
 def test_adsb_surface_position_with_ref():
     pos = adsb.surface_position_with_ref(
         "8FC8200A3AB8F5F893096B000000", -43.5, 172.5

--- a/tests/test_adsb.py
+++ b/tests/test_adsb.py
@@ -58,7 +58,7 @@ def test_adsb_airborne_position_with_ref_numerical_challenge():
     lat_ref = 30.508474576271183 # Close to (360.0/59.0)*5
     lon_ref = 7.2*5.0+3e-15
     pos = adsb.airborne_position_with_ref(
-        "8D06A15358BF17FF7D4A84", lat_ref, lon_ref
+        "8D06A15358BF17FF7D4A84B47B95", lat_ref, lon_ref
     )
     assert pos == (approx(30.50540, 0.001), approx(33.44787, 0.001))
 


### PR DESCRIPTION
Thank you for this excellent library.

I noticed this problem decoding some ADS-B messages. The local airborne decoding failed is some particular cases.

There seems to be some oddities with the Python modulus operator. E.g.:
```
>>> 30.508474576271183 % 6.101694915254237
6.101694915254235
>>> import math
>>> def mod(x, y):
...     return x - y * math.floor(x / y)
...
>>> mod(30.508474576271183, 6.101694915254237)
0.0
```
Checking the standard (1090 MOPS, Vol.1  DO-260C), section 1.7.5 in Appendix A, shows an equivalent and simpler expression that doesn't require use of a modulus function. I think this should be the preferred approach since it's more accurate and requires less computations. 