### PR TITLE
Explicitly set multiprocessing start method to fork for OSX support

### DIFF
--- a/src/pyModeS/streamer/modeslive.py
+++ b/src/pyModeS/streamer/modeslive.py
@@ -91,6 +91,12 @@ def main():
     # redirect all stdout to null, avoiding messing up with the screen
     sys.stdout = open(os.devnull, "w")
 
+    # Explicitly set the start method to fork to avoid errors when running
+    # on OSX which otherwise defaults to spawn. Starting in Python 3.14, fork
+    # must be explicitly set if needed.
+    # See: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    multiprocessing.set_start_method("fork")
+
     raw_pipe_in, raw_pipe_out = multiprocessing.Pipe()
     ac_pipe_in, ac_pipe_out = multiprocessing.Pipe()
     exception_queue = multiprocessing.Queue()


### PR DESCRIPTION
## Summary
This fixes an issue preventing pyModeS from being usable on OSX. The root cause of the issue is that the default start method for multiprocessing on OSX is `spawn` which is not compatible with pyModeS. Additionally, as of Python 3.14 `fork` must be specified explicitly. See: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

There's probably a better way to clean this up however this is the simplest fix for now.

## Testing Done
1. Checked OSX (15.2) run

Before:
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/a588fb2f-aee2-4fbe-8cb3-51f72bfd108e" />

After
![image](https://github.com/user-attachments/assets/24fd02c7-1184-453d-94c3-bdebef800d8a)

2. Checked Linux run before/after change no difference