### PR TITLE
Fix floating point display on terminal output

### DIFF
--- a/src/pyModeS/streamer/screen.py
+++ b/src/pyModeS/streamer/screen.py
@@ -70,6 +70,18 @@ class Screen(object):
             % len(self.acs),
         )
 
+
+    def round_float(self, value, max_width):
+        # Constrain a floating point number to a maximum string size.
+        # Subtract 2 to account for decimal and column spacing.
+
+        sign_size = 1 if value < 0 else 0
+        int_size = len(str(int(value)))
+        max_precision = max_width - int_size - sign_size - 2
+        rounded_value = round(value, max_precision)
+
+        return f"{rounded_value:.{max_precision}f}"
+
     def update(self):
         if len(self.acs) == 0:
             return
@@ -127,6 +139,10 @@ class Screen(object):
                         val = ""
                     else:
                         val = ac[c]
+
+                    if isinstance(val, float):
+                        val = self.round_float(val, cw)
+
                     val_str = str(val)
                     line += (cw - len(val_str)) * " " + val_str
 


### PR DESCRIPTION
## Summary
The current implementation of `modeslive` on terminal screens creates difficult to read formatting due to floating point precision larger than the defined column widths. This PR makes an adjustment to round floating point numbers to the defined column width to improve readability.  This resolves issue https://github.com/junzis/pyModeS/issues/178

This behavior may have been caused by https://github.com/junzis/pyModeS/pull/147. For visual user output it probably makes sense to at least keep some formatting in the terminal view. This PR does not affect any other internal calculations or the `dump` output.

The logic is:

- Determine if there is a negative sign in the output
- Account for the decimal point
- From the column width, subtract the negative sign, decimal, and one extra space to allow spacing between columns.
- Round the floating point rather than truncating for additional accuracy
- Use string formatting to maintain trailing zeros for visual improvement

## Testing Done
Before: Fields not aligned with columns and spilling around

<img width="839" alt="image" src="https://github.com/user-attachments/assets/5d75d86d-99d7-4cfe-8683-bfb9ace39f3f" />

After: Fields behave correctly.
<img width="709" alt="image" src="https://github.com/user-attachments/assets/4145f87c-3b7e-43bc-935f-b67fb165b46b" />

Confirmed no impact to `--dump` output